### PR TITLE
Fix Sinon dependency

### DIFF
--- a/blueprints/ember-cli-betamax/index.js
+++ b/blueprints/ember-cli-betamax/index.js
@@ -20,7 +20,7 @@ module.exports = {
 
             // Import statement
             //
-            return this.addBowerPackageToProject('sinon=http://sinonjs.org/releases/sinon-1.12.2.js')
+            return this.addBowerPackageToProject('sinon', 'http://sinonjs.org/releases/sinon-1.12.2.js')
 
             .then(function(){
               return this.insertIntoFile( firstFile, firstText, { after: firstLocationText } )


### PR DESCRIPTION
The syntax for `addBowerPackageToProject` changed (see https://github.com/ember-cli/ember-cli/pull/4643), so this was resulting in an error 404 on installation with recent versions of Ember CLI.
